### PR TITLE
Format under cursor causes loss of data. #48

### DIFF
--- a/src/ttMarkdown.ts
+++ b/src/ttMarkdown.ts
@@ -71,7 +71,7 @@ export class MarkdownParser implements tt.Parser {
 
     isSeparatorRow(text: string): boolean {
         const cleaned = text.replace(/\s+/g, '');
-        return cleaned.startsWith('|-') || cleaned.startsWith('|:-');
+        return (cleaned.startsWith('|-') || cleaned.startsWith('|:-')) && cleaned.match(/^[:|-\s]+$/) ? true : false;
     }
 }
 

--- a/src/ttOrg.ts
+++ b/src/ttOrg.ts
@@ -38,7 +38,7 @@ export class OrgParser implements tt.Parser {
     }
 
     isSeparatorRow(text: string): boolean {
-        return text.length > 1 && text[1] === horizontalSeparator;
+        return text.length > 1 && text[1] === horizontalSeparator && text.match(/^[+|-\s]+$/) ? true : false;;
     }
 }
 

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -28,7 +28,24 @@ suite('Commands', () => {
 | -1 | -1 |`;
         
         await inTextEditor({language: 'markdown', content: testCase}, async (editor, document) => {
-            await cfg.override({mode: 'markdown'});
+            await cfg.override({mode: cfg.Mode.Markdown});
+            move(editor, 0, 1);
+            await vscode.commands.executeCommand('text-tables.gotoNextCell');
+
+            assert.equal(document.getText(), expected);
+        });
+    });
+
+    test('Regression: Format under cursor causes loss of data (org).', async () => {
+        const testCase =
+        `|A|B|
+|-1|-1|`;
+        const expected =
+        `| A  | B  |
+| -1 | -1 |`;
+        
+        await inTextEditor({language: 'markdown', content: testCase}, async (editor, document) => {
+            await cfg.override({mode: cfg.Mode.Org});
             move(editor, 0, 1);
             await vscode.commands.executeCommand('text-tables.gotoNextCell');
 

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -19,6 +19,23 @@ function move(editor: vscode.TextEditor, line: number, col: number) {
 }
 
 suite('Commands', () => {
+    test('Regression: Format under cursor causes loss of data.', async () => {
+        const testCase =
+        `| A| B|
+        | -1| -1|`;
+        const expected =
+        `| A  | B  |
+| -1 | -1 |`;
+        
+        await inTextEditor({language: 'markdown', content: testCase}, async (editor, document) => {
+            await cfg.override({mode: 'markdown'});
+            move(editor, 0, 1);
+            await vscode.commands.executeCommand('text-tables.gotoNextCell');
+
+            assert.equal(document.getText(), expected);
+        });
+    });
+
     test('Test "Create table" for markdown', async () => {
         const expectedResult = `|     |     |
 | --- | --- |

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -22,7 +22,7 @@ suite('Commands', () => {
     test('Regression: Format under cursor causes loss of data.', async () => {
         const testCase =
         `| A| B|
-        | -1| -1|`;
+| -1| -1|`;
         const expected =
         `| A  | B  |
 | -1 | -1 |`;


### PR DESCRIPTION
fixes https://github.com/rpeshkov/vscode-text-tables/issues/48